### PR TITLE
Fix typo event_name according to official OpenAI documentation

### DIFF
--- a/server/src/langchain_openai_voice/__init__.py
+++ b/server/src/langchain_openai_voice/__init__.py
@@ -246,7 +246,7 @@ class OpenAIVoiceReactAgent(BaseModel):
                     t = data["type"]
                     if t == "response.audio.delta":
                         await send_output_chunk(json.dumps(data))
-                    elif t == "response.audio_buffer.speech_started":
+                    elif t == "input_audio_buffer.speech_started":
                         print("interrupt")
                         send_output_chunk(json.dumps(data))
                     elif t == "error":


### PR DESCRIPTION
`response.audio_buffer.speech_started` to `input_audio_buffer.speech_started`

Refer to: https://platform.openai.com/docs/api-reference/realtime-server-events/input-audio-buffer-speech-started